### PR TITLE
Adding links to new Wiki pages

### DIFF
--- a/src/documents/index.html.jade
+++ b/src/documents/index.html.jade
@@ -53,7 +53,9 @@ HideNav: true
       contributions from people like you.
       Confused? [File an issue!](https://github.com/nightscout/nightscout.github.io/issues)
       * [wiki-a help desk](https://github.com/nightscout/nightscout.github.io/wiki)
-      * [Android Devices with workable usb host](/pdfs/Android-Devices-with-workable-usb-host-FB.pdf)
+      * [NightScout Uploader Devices](https://github.com/nightscout/nightscout.github.io/wiki/NightscoutUploaders): Phones, Tablets, Set Top Boxes
+      * [Carriers](https://github.com/nightscout/nightscout.github.io/wiki/Carriers)
+      
     p
   .col-md-6
     div: :markdown


### PR DESCRIPTION
Added link to the Carriers page on the Wiki.
Replaced "Android Devices with workable usb host" with NightscoutUploaders page from the Wiki. I believe most if not all of the info in this PDF is available on this Wiki page.
- [Android Devices with workable usb host](/pdfs/Android-Devices-with-workable-usb-host-FB.pdf)
