### PR TITLE
Fix URL rendering for Children with Diabetes

### DIFF
--- a/src/documents/index.html.jade
+++ b/src/documents/index.html.jade
@@ -84,6 +84,4 @@ HideNav: true
       Social media / friends
       * [#wearenotwaiting @ Twitter](https://twitter.com/hashtag/wearenotwaiting?src=hash)
       * [Our Friends: Tidepool](https://tidepool.org/)
-      * [Our Friends for Life: Children with Diabetes] (http://www.childrenwithdiabetes.com/)      
-
-
+      * [Our Friends for Life: Children with Diabetes](https://www.childrenwithdiabetes.com/)      


### PR DESCRIPTION
There was a space between the bracket and parenthesis, and the site also uses HTTPS, so fixed that.