### PR TITLE
fix: Swap order of Atlas database form fields

### DIFF
--- a/docs/nightscout/new_user.md
+++ b/docs/nightscout/new_user.md
@@ -243,9 +243,9 @@ e) Select `Username and Password` and invent a database username (for example `n
 
 Write down these credentials in the lines below (yes, in this browser window you're reading now, unless you're reading a printed version). You’ll need them later.
 
-Database password (write here ->) <input type="text" id="myPwd" value="click here, delete and put your own" size="30">
+<b>Database username</b> (write here ->) <input type="text" id="myUsr" value="click here, delete and put your own" size="30">
 
-Database username (write here ->) <input type="text" id="myUsr" value="click here, delete and put your own" size="30">
+<b>Database password</b> (write here ->) <input type="text" id="myPwd" value="click here, delete and put your own" size="30">
 
 </br>
 


### PR DESCRIPTION
The form fields for the Atlas database username and database user password were listed with the password first and the username second, which is really unintuitive. This has caused several users I have helped to confuse the two because they assumed the username was the first field, by convention.