### PR TITLE
fix information about t1pal

### DIFF
--- a/docs/nightscout/new_user.md
+++ b/docs/nightscout/new_user.md
@@ -1215,7 +1215,7 @@ Need more? Look at [advanced](../advanced) install methods.
   border-top:0.05rem solid var(--md-typeset-table-color)'>2GB</td>
   <td class=xl91543 width=94 style='border-top:none;width:71pt;box-sizing: inherit;
   border-top:0.05rem solid var(--md-typeset-table-color)'>Low</td>
-  <td class=xl102543 style='border-top:none'>No remote carbs/bolus (Loop)</td>
+  <td class=xl102543 style='border-top:none'></td>
  </tr>
  <tr class=xl89543 height=20 style='height:15.35pt;box-sizing: inherit;
   transition: background-color 125ms ease 0s'>


### PR DESCRIPTION
Remote controls in Loop are supported by T1Pal.
Availability for alternative versions other than the main supported release is supported on a limited basis.  There are people on T1Pal using remote overrides, remote carbs, and remote bolus on a spectrum of Loop versions. Since remote carbs and remote bolus are only supported in Loop-dev, it's incorrect to say that "Loop supports remote carbs," or say that "T1Pal doesn't support remote carbs."  Loop-dev may support the feature, but Loop does not. Most developers strongly prefer non-developers use the released version of software.

See https://github.com/LoopKit/loopdocs/pull/515 for more information.