### PR TITLE
✏️ Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ sphinx-build -b dirhtml docs _build
 * Start a local http server to view the documentation
 
 ```bash
-$ cd <nightscout docs location>/_build
+$ cd <nightscout docs location>/_build/dirhtml
 $ python -m http.server
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ sphinx-build -b dirhtml docs _build
 * Start a local http server to view the documentation
 
 ```bash
-$ cd <nightscout docs location>/_build/dirhtml
+$ cd <nightscout docs location>/_build
 $ python -m http.server
 ```
 

--- a/docs/uploader/setup.md
+++ b/docs/uploader/setup.md
@@ -3,7 +3,7 @@
 </br>
 
 ```{hint}
-You usually should express the Nightscout URL in secure `**https://**`, not only `http://`.
+You usually should express the Nightscout URL in secure **`https://`**, not only `http://`.
 (Unless you set `INSECURE_USE_HTTP` to `true`)
 ```
 


### PR DESCRIPTION
This PR fixes a few typos on the following pages:
- `Setup Uploaders` where the inline-code block should be bold whereas it is messed up 
  > ❌ ![CleanShot 2025-02-17 at 15 28 51@2x](https://github.com/user-attachments/assets/c160e9ad-09ed-4b95-8479-c92948bbd8d6)
  > ✅ ![CleanShot 2025-02-17 at 15 28 37@2x](https://github.com/user-attachments/assets/1307b765-1208-4eeb-b59d-4c6d4964a661)
- ~~`README.md` where the folder containing generated HTML files should now be `_build` instead of `_build/dirhtml`, according to my understanding of Sphinx v5.3.0 output:~~
  ```shell
  cd nightscout.github.io
  sphinx-build -b dirhtml docs _build
  
    Running Sphinx v5.3.0
    loading pickled environment... done
    myst v1.0.0: MdParserConfig(commonmark_only=False, gfm_only=False, enable_extensions={'html_admonition', 'html_image', 'colon_fence'}, disable_syntax=[], all_links_external=False, url_schemes=('http', 'https', 'mailto', 'ftp'), ref_domains=None, fence_as_directive=set(), number_code_blocks=[], title_to_header=False, heading_anchors=6, heading_slug_func=None, html_meta={}, footnote_transition=True, words_per_minute=200, substitutions={}, linkify_fuzzy_links=True, dmath_allow_labels=True, dmath_allow_space=True, dmath_allow_digits=True, dmath_double_inline=False, update_mathjax=True, mathjax_classes='tex2jax_process|mathjax_process|math|output_area', enable_checkboxes=False, suppress_warnings=[], highlight_code_blocks=True)
    building [mo]: targets for 0 po files that are out of date
    building [dirhtml]: targets for 0 source files that are out of date
    updating environment: 0 added, 0 changed, 0 removed
    looking for now-outdated files... none found
    no targets are out of date.
    build succeeded.

    The HTML pages are in _build.
 
  # cd ../nightscout.github.io/_build/dirhtml # <== ❌ Folder does not exist
  cd ../nightscout.github.io/_build           # <== ✅
  python -m http.server
  ```

