### PR TITLE
💚 ⬆️ Fix CI/CD Docs Build Workflow and Upgrade Project Dependencies

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -6,8 +6,8 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -15,7 +15,7 @@ jobs:
         run: |
           sphinx-build -b dirhtml docs _build
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/source' }}
         with:
           publish_branch: gh-pages

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.13"
     # You can also specify other tool versions:
     # nodejs: "19"
     # rust: "1.64"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: dirhtml
    configuration: docs/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Sphinx==5.3.0
+sphinx==8.2.0
 sphinx-copybutton==0.5.2
-sphinx_design==0.4.1
-sphinx-rtd-theme==1.2.0
-myst-parser==1.0.0
-sphinx-notfound-page==1.0.4
+sphinx_design==0.6.1
+sphinx-rtd-theme==3.0.2
+myst-parser==4.0.1
+sphinx-notfound-page==1.1.0


### PR DESCRIPTION
This PR:
- upgrades the **project dependencies (Python packages)**  
  
  Package                | From Version | To Version
  ---                    | ---:          | ---:
  `sphinx`               | 5.3          | 8.2.0
  `sphinx_design`        | 0.4.1        | 0.6.1
  `sphinx-rtd-theme`     | 1.2.0        | 3.0.2
  `myst-parser`          | 1.0.0        | 4.0.1
  `sphinx-notfound-page` | 1.0.4        | 1.1.0
  
  - This fixes #229 .
- **upgrades** the outdated **GitHub Actions** used in the **Docs build** (`documentation.yaml`) GitHub **workflow**  
  GitHub Action               | From Version | To Version
  ---                         | ---:          | ---:
  `actions/checkout`          | v3           | v4
  `setup/python`              | v3           | v5
  `peaceiris/actions-gh-page` | v3           | v4
  
- switches to using **Ubuntu 24.04** as this is now the default Ubuntu version for `ubuntu-latest`.

> `ubuntu-latest` pipelines will use `ubuntu-24.04` soon. For more details, see https://github.com/actions/runner-images/issues/10636 .
> GitHub Actions has transitioned the `ubuntu-latest` label to point to Ubuntu 24.04 as of January 17, 2025. 
> If your workflows use `ubuntu-latest`, they are now running on *Ubuntu* `24.04`. 
> To avoid unexpected changes in your build environment, 
> it is recommended to specify the exact version (`ubuntu-24.04`) rather than using `ubuntu-latest`. 
