### PR TITLE
✏️ Fix Doc build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ pip install -r requirements.txt
 
 ```bash
 $ cd <nightscout docs location>
-$ sphinx-build -b dirhtml docs _build
+$ sphinx-build -M dirhtml docs _build
 ```
 
 * Start a local http server to view the documentation


### PR DESCRIPTION
This PR corrects a typo in the README, where the command used to build the documentation generates the files in `_build`, but it should be in `_build/dirhtml`.

Blocked by #230