### PR TITLE
👷 Fix CI: Docs Build Command

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -15,7 +15,7 @@ jobs:
           pip install -r requirements.txt
       - name: Sphinx build
         run: |
-          sphinx-build -b dirhtml docs _build
+          sphinx-build -M dirhtml docs _build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/source' }}


### PR DESCRIPTION
This PR updates the [Docs build GitHub Workflow](https://github.com/nightscout/nightscout.github.io/blob/ebde65c1b6fa0b7949df037f78ce0b856721944a/.github/workflows/documentation.yaml#L18) to use **`sphinx-build` `-M`** option to ensure it aligns with what is documented in the README.